### PR TITLE
fix: SyntaxError unterminated string literal

### DIFF
--- a/src/unit_text/cli.py
+++ b/src/unit_text/cli.py
@@ -180,13 +180,7 @@ Reference specific parts of the text when making suggestions.
                     style="green",
                 ),
             ),
-            title=f"{title}"
-            " "
-            f"({
-                '[bold green]Passed[/]'
-                if evaluation.test_passed
-                else '[bold red]Failed[/]'
-            })",
+            title=f"{title} ({'[bold green]Passed[/]' if evaluation.test_passed else '[bold red]Failed[/]'})",
         )
 
     panel_group = Group(


### PR DESCRIPTION
Hello @borgoat ,

nice tool! I was giving it a test and got an error when running it:
```
uvx unit-text --help
...
uv/archive-v0/JLU3uX1TlNXm8NiyDoqO3/lib/python3.11/site-packages/unit_text/cli.py", line 185
    f"({
    ^
SyntaxError: unterminated string literal (detected at line 185)
```.
Somehow it did not like the formatting. Transforming it to a one-liner solved it. 
